### PR TITLE
fix: close tempfile handle

### DIFF
--- a/synapse_to_ipynb.py
+++ b/synapse_to_ipynb.py
@@ -73,7 +73,7 @@ class NotebookDirectoryManager:
 
             # Update the temporary synpase notebook file's 'cells'
             # property with the ipynb src we read earlier
-            with open(tmp_notebook_path, "r+") as f:
+            with os.fdopen(fd, "r+") as f:
                 synnb_json = json.load(f)
                 synnb_json["properties"]["cells"] = ipynb_cells
                 f.seek(0)


### PR DESCRIPTION
On Windows, replacing the synapse notebook with the temporary file on update fails with:
```
PermissionError - [WinError 32] The process cannot access the file because it is being used by another process
```
The problem seems to be an open  file descriptor returned by tempfile.mkstemp. Opening the temporary file for writing through fdopen and the file descriptor returned by mkstemp (instead of open by path) cleans up the fd at the end of the with block, fixing the error on subsequent os.replace.